### PR TITLE
Include benchmark timestamp to avoid overwriting measurements.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,6 +101,9 @@ val ui = project.settings(
 )
 
 lazy val DottyRef = ".*-([^-]+)-NIGHTLY".r
+lazy val timestamp =
+  new java.text.SimpleDateFormat("yyyyMMdd_kkmmss")
+    .format(new java.util.Date())
 
 lazy val batchTasks = taskKey[List[String]]("")
 batchTasks := tasks
@@ -113,9 +116,10 @@ lazy val tasks = {
     )
     scalaVersion = s" -DscalaVersion=$version"
     baseSourceDir = sys.props.getOrElse("gitrepos", "/home/benchs").stripSuffix("/")
+    benchmarkTimestamp = s" -DbenchmarkTimestamp=$timestamp"
     scalaRef = s" -DscalaRef=$ref"
     localdir = s" -Dgit.localdir=$baseSourceDir/$sourceDirectory"
-    sysProps = s"$scalaVersion $scalaRef $localdir"
+    sysProps = s"$scalaVersion $scalaRef $localdir $benchmarkTimestamp"
     runUpload = s"compilation/jmh:runMain $sysProps scala.bench.UploadingRunner "
     inputProject <- List("vector", "squants")
     source = s"-p source=$inputProject"

--- a/infrastructure/src/main/java/scala/bench/GitWalker.java
+++ b/infrastructure/src/main/java/scala/bench/GitWalker.java
@@ -32,6 +32,8 @@ public class GitWalker {
         if (System.getProperty("git.localdir").contains("dotty")) {
             createPoints("master", "ae4f1fa353", batchPoints, repo, branchesMap);
         } else {
+            createPoints("2.13.x", "fc1aea6712", batchPoints, repo, branchesMap);
+            createPoints("2.12.x", "132a0587ab", batchPoints, repo, branchesMap);
             createPoints("2.11.x", "18f625db1c", batchPoints, repo, branchesMap);
         }
         return new GitWalkerResult(batchPoints, branchesMap, repo);

--- a/infrastructure/src/main/java/scala/bench/UploadingOutputFormat.java
+++ b/infrastructure/src/main/java/scala/bench/UploadingOutputFormat.java
@@ -71,6 +71,7 @@ public class UploadingOutputFormat extends DelegatingOutputFormat {
             BenchmarkParams params = result.getParams();
             Collection<String> paramsKeys = params.getParamsKeys();
             pointBuilder.tag("label", result.getPrimaryResult().getLabel());
+            pointBuilder.tag("benchmarkTimestamp", System.getProperty("benchmarkTimestamp"));
             String benchmarkName = result.getParams().getBenchmark()
                     .replace(".compile", "")
                     .replace("scala.tools.nsc.", "")

--- a/run-bench.sh
+++ b/run-bench.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euox pipefail
+# assumes that dotty/scala/compiler-benchmark are sibling directories.
+# It's necessary to pull in the scala/dotty repos in order to fetch the latest
+# commit messages.
+gitrepos=${1:-$HOME}
+cd $gitrepos/dotty && git checkout master && git pull origin master
+cd $gitrepos/scala && git checkout 2.13.x && git pull origin 2.13.x
+cd $gitrepos/compiler-benchmark && git pull origin dotty && sbt -Dgitrepos=$gitrepos runBatch


### PR DESCRIPTION
Currently, the scalac benchmark measurements get overwritten on every
run because the git commit and other tags are unchanged from each
benchmark run. This commit adds a new tag to measurements which is the
timestamp of the benchmark.