### PR TITLE
Compare with 2.12 nightly instead of 2.13.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ resolvers ++= (
 lazy val latestScalacVersion = sys.props.getOrElse(
   "scalacVersion", {
     val view = scala.io.Source.fromURL(
-      "https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-bootstrap/lastSuccessfulBuild/artifact/jenkins.properties/*view*/")
+      "https://scala-ci.typesafe.com/job/scala-2.12.x-integrate-bootstrap/lastSuccessfulBuild/artifact/jenkins.properties/*view*/")
     val props = new java.util.Properties()
     props.load(new StringReader(view.mkString))
     val version = props.getProperty("version")

--- a/run-bench.sh
+++ b/run-bench.sh
@@ -5,5 +5,5 @@ set -euox pipefail
 # commit messages.
 gitrepos=${1:-$HOME}
 cd $gitrepos/dotty && git checkout master && git pull origin master
-cd $gitrepos/scala && git checkout 2.13.x && git pull origin 2.13.x
+cd $gitrepos/scala && git checkout 2.12.x && git pull origin 2.12.x
 cd $gitrepos/compiler-benchmark && git pull origin dotty && sbt -Dgitrepos=$gitrepos runBatch


### PR DESCRIPTION
Most of the ongoing optimizations in scalac seem to be happening in
2.12.x.